### PR TITLE
Feat : Schedule API Link

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/local/SharedPreference.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/local/SharedPreference.kt
@@ -28,4 +28,8 @@ object SharedPreference {
     fun getCode(): Int? = pref?.getInt(CODE, 0)
     fun setCode(code: Int) = pref?.edit()?.putInt(CODE, code)?.apply()
 
+    // 학사 일정
+    private const val SCHEDULE = "SCHEDULE"
+    fun getSchedule(): String? = pref?.getString(SCHEDULE, "No Data")
+    fun setSchedule(schedule: String) = pref?.edit()?.putString(SCHEDULE, schedule)?.apply()
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Schedule.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Schedule.kt
@@ -1,7 +1,6 @@
 package com.dongyang.android.youdongknowme.data.remote.entity
 
 data class Schedule (
-    var id : Int,
     var date : String,
     var contents : String
     )

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Schedule.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Schedule.kt
@@ -1,6 +1,9 @@
 package com.dongyang.android.youdongknowme.data.remote.entity
 
-data class Schedule (
-    var date : String,
-    var contents : String
-    )
+
+data class Schedule(
+    var year: String,
+    var month: Int,
+    var date: String,
+    var content: String
+)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/ScheduleService.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/ScheduleService.kt
@@ -1,0 +1,11 @@
+package com.dongyang.android.youdongknowme.data.remote.service
+
+import com.dongyang.android.youdongknowme.data.remote.entity.Schedule
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface ScheduleService {
+    @GET("/schedule")
+    suspend fun getScheduleList(
+    ) : Response<List<Schedule>>
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/ScheduleRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/ScheduleRepository.kt
@@ -1,12 +1,21 @@
 package com.dongyang.android.youdongknowme.data.repository
 
+import com.dongyang.android.youdongknowme.data.local.SharedPreference
 import com.dongyang.android.youdongknowme.data.remote.entity.Schedule
 import com.dongyang.android.youdongknowme.data.remote.service.ScheduleService
 import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
 import retrofit2.Response
 
 class ScheduleRepository {
-    suspend fun getNoticeList() : Response<List<Schedule>> {
+    suspend fun getNoticeList(): Response<List<Schedule>> {
         return RetrofitObject.getNetwork().create(ScheduleService::class.java).getScheduleList()
+    }
+
+    fun setLocalSchedule(schedule: String) {
+        SharedPreference.setSchedule(schedule)
+    }
+
+    fun getLocalSchedule(): String {
+        return SharedPreference.getSchedule()!!
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/ScheduleRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/ScheduleRepository.kt
@@ -1,4 +1,12 @@
 package com.dongyang.android.youdongknowme.data.repository
 
+import com.dongyang.android.youdongknowme.data.remote.entity.Schedule
+import com.dongyang.android.youdongknowme.data.remote.service.ScheduleService
+import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
+import retrofit2.Response
+
 class ScheduleRepository {
+    suspend fun getNoticeList() : Response<List<Schedule>> {
+        return RetrofitObject.getNetwork().create(ScheduleService::class.java).getScheduleList()
+    }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/base/BaseViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/base/BaseViewModel.kt
@@ -18,6 +18,7 @@ abstract class BaseViewModel : ViewModel() {
 
     val connectionHandler = CoroutineExceptionHandler { _, e ->
         e.printStackTrace()
+        _isLoading.postValue(false)
         _errorConnectionState.postValue(ERROR_NETWORK)
     }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
@@ -1,9 +1,6 @@
 package com.dongyang.android.youdongknowme.standard.di
 
-import com.dongyang.android.youdongknowme.data.repository.DepartRepository
-import com.dongyang.android.youdongknowme.data.repository.DetailRepository
-import com.dongyang.android.youdongknowme.data.repository.NoticeRepository
-import com.dongyang.android.youdongknowme.data.repository.SplashRepository
+import com.dongyang.android.youdongknowme.data.repository.*
 import com.dongyang.android.youdongknowme.ui.view.depart.DepartViewModel
 import com.dongyang.android.youdongknowme.ui.view.detail.DetailViewModel
 import com.dongyang.android.youdongknowme.ui.view.notice.NoticeViewModel
@@ -18,7 +15,7 @@ val viewModelModule = module {
         NoticeViewModel(get())
     }
     viewModel {
-        ScheduleViewModel()
+        ScheduleViewModel(get())
     }
     viewModel {
         SettingViewModel()
@@ -46,5 +43,8 @@ val repositoryModule = module {
     }
     single {
         DepartRepository()
+    }
+    single {
+        ScheduleRepository()
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
@@ -1,7 +1,6 @@
 package com.dongyang.android.youdongknowme.ui.view.notice
 
 import android.content.Intent
-import android.os.Bundle
 import android.view.inputmethod.EditorInfo
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -11,10 +10,9 @@ import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.FragmentNoticeBinding
 import com.dongyang.android.youdongknowme.standard.base.BaseFragment
 import com.dongyang.android.youdongknowme.standard.util.hideKeyboard
-import com.dongyang.android.youdongknowme.standard.util.log
 import com.dongyang.android.youdongknowme.standard.util.showKeyboard
 import com.dongyang.android.youdongknowme.ui.adapter.NoticeAdapter
-import com.dongyang.android.youdongknowme.ui.view.LoadingDialog
+import com.dongyang.android.youdongknowme.ui.view.depart.DepartActivity
 import com.dongyang.android.youdongknowme.ui.view.detail.DetailActivity
 import com.google.android.material.tabs.TabLayout
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -106,6 +104,11 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
             }
 
             false
+        }
+
+        binding.noticeToolbar.toolbarAlarm.setOnClickListener {
+            val intent = Intent(requireActivity(), DepartActivity::class.java)
+            startActivity(intent)
         }
 
         // 툴바의 X버튼 눌렀을 때 동작

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleFragment.kt
@@ -1,6 +1,5 @@
 package com.dongyang.android.youdongknowme.ui.view.schedule
 
-import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.dongyang.android.youdongknowme.R
@@ -8,6 +7,7 @@ import com.dongyang.android.youdongknowme.databinding.FragmentScheduleBinding
 import com.dongyang.android.youdongknowme.standard.base.BaseFragment
 import com.dongyang.android.youdongknowme.standard.util.log
 import com.dongyang.android.youdongknowme.ui.adapter.ScheduleAdapter
+import com.prolificinteractive.materialcalendarview.CalendarDay
 import org.threeten.bp.LocalDate
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -24,7 +24,7 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding, ScheduleViewModel
     private lateinit var adapter : ScheduleAdapter
 
     override fun initStartView() {
-        log(binding.scheduleCalendar.currentDate.date.toString()) // 달력 초기 데이터 (2022-04-01)
+        viewModel.setPickDate(binding.scheduleCalendar.currentDate)
         adapter = ScheduleAdapter()
         binding.scheduleRvList.apply {
             this.adapter = this@ScheduleFragment.adapter
@@ -35,17 +35,28 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding, ScheduleViewModel
     }
 
     override fun initDataBinding() {
-        adapter.submitList(viewModel.testCode)
+        viewModel.pickMonth.observe(viewLifecycleOwner) {
+            viewModel.getScheduleList()
+        }
+
+        viewModel.scheduleList.observe(viewLifecycleOwner) {
+            adapter.submitList(it)
+        }
     }
 
     override fun initAfterBinding() {
-
-        // TODO :: 월 변경될 때마다 일정 리스트도 변경하기
-        // TODO :: MinDate, MaxDate 설정 필요(리소스 감소)
+        
         binding.scheduleCalendar.setOnMonthChangedListener { _, date ->
-            val currentDate = date.year.toString() + "." + date.month.toString() // 2022.4
-            adapter.submitList(viewModel.testCode2)
-            log(currentDate)
+            viewModel.setPickDate(date)
+            log(date.month.toString())
+        }
+
+        // 최소 날짜, 최대 날짜 지정
+        binding.scheduleCalendar.apply {
+            this.state().edit().
+                setMinimumDate(CalendarDay.from(2022, 1, 1))
+                .setMaximumDate(CalendarDay.from(2023, 2, 28))
+                .commit()
         }
 
         // 연/월 방식으로 타이틀 처리

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleFragment.kt
@@ -5,12 +5,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.FragmentScheduleBinding
 import com.dongyang.android.youdongknowme.standard.base.BaseFragment
-import com.dongyang.android.youdongknowme.standard.util.log
 import com.dongyang.android.youdongknowme.ui.adapter.ScheduleAdapter
 import com.prolificinteractive.materialcalendarview.CalendarDay
 import org.threeten.bp.LocalDate
 import org.koin.androidx.viewmodel.ext.android.viewModel
-
 
 /* 학사 일정 화면 */
 class ScheduleFragment : BaseFragment<FragmentScheduleBinding, ScheduleViewModel>() {
@@ -35,8 +33,13 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding, ScheduleViewModel
     }
 
     override fun initDataBinding() {
+        viewModel.isLoading.observe(viewLifecycleOwner) {
+            if(it) showLoading()
+            else dismissLoading()
+        }
+
         viewModel.pickMonth.observe(viewLifecycleOwner) {
-            viewModel.getScheduleList()
+            viewModel.getLocalScheduleList()
         }
 
         viewModel.scheduleList.observe(viewLifecycleOwner) {
@@ -45,10 +48,9 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding, ScheduleViewModel
     }
 
     override fun initAfterBinding() {
-        
+
         binding.scheduleCalendar.setOnMonthChangedListener { _, date ->
             viewModel.setPickDate(date)
-            log(date.month.toString())
         }
 
         // 최소 날짜, 최대 날짜 지정

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleViewModel.kt
@@ -3,11 +3,15 @@ package com.dongyang.android.youdongknowme.ui.view.schedule
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import com.dongyang.android.youdongknowme.standard.base.BaseViewModel
+import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.data.remote.entity.Schedule
 import com.dongyang.android.youdongknowme.data.repository.ScheduleRepository
+import com.dongyang.android.youdongknowme.standard.base.BaseViewModel
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.prolificinteractive.materialcalendarview.CalendarDay
 import kotlinx.coroutines.launch
+
 
 /* 학사 일정 뷰모델 */
 class ScheduleViewModel(private val scheduleRepository: ScheduleRepository) : BaseViewModel() {
@@ -21,29 +25,49 @@ class ScheduleViewModel(private val scheduleRepository: ScheduleRepository) : Ba
     private val _pickMonth = MutableLiveData<Int>()
     val pickMonth: LiveData<Int> get() = _pickMonth
 
+    private val _errorState: MutableLiveData<Int> = MutableLiveData()
+    val errorState: LiveData<Int> = _errorState
+
     fun setPickDate(date: CalendarDay) {
         _pickYear.value = date.year
         _pickMonth.value = date.month
     }
 
-    fun getScheduleList() {
-        _isLoading.postValue(true)
-        try {
-            viewModelScope.launch(connectionHandler) {
-                val response = scheduleRepository.getNoticeList()
+    fun getLocalScheduleList() {
+        // 로컬에 저장한 데이터가 없으면 네트워크에서 데이터를 받아와 로컬에 저장 및 화면에 출력
+        if (scheduleRepository.getLocalSchedule() == "No Data") {
+            _isLoading.postValue(true)
+            try {
+                viewModelScope.launch(connectionHandler) {
+                    val response = scheduleRepository.getNoticeList()
 
-                if(response.isSuccessful) {
-                    val scheduleList = response.body()!!.filter {
-                        it.year == pickYear.value.toString() &&
-                        it.month == pickMonth.value
+                    if (response.isSuccessful) {
+                        // 선택한 연월 조건에 따라 리스트 출력
+                        _scheduleList.postValue(response.body()?.filter { it.month == pickMonth.value && it.year == pickYear.value.toString() })
+                        scheduleRepository.setLocalSchedule(Gson().toJson(response.body()))
+                    } else {
+                        _errorState.postValue(ERROR_SCHEDULE)
                     }
-
-                    _scheduleList.postValue(scheduleList)
+                    _isLoading.postValue(false)
                 }
+            } catch (e: Exception) {
                 _isLoading.postValue(false)
+                _errorState.postValue(ERROR_SCHEDULE)
             }
-        } catch (e: Exception) {
-            _isLoading.postValue(false)
+        } else {
+            // 저장한 데이터가 있으면 로컬에서 곧바로 데이터를 받아와 화면에 출력
+            val tmp = scheduleRepository.getLocalSchedule()
+            val scheduleList =
+                Gson().fromJson<List<Schedule>>(tmp, object : TypeToken<List<Schedule>>() {}.type).filter {
+                    // 선택한 연월 조건에 따라 리스트 출력
+                    it.month == pickMonth.value && it.year == pickYear.value.toString()
+                }
+
+            _scheduleList.postValue(scheduleList)
         }
+    }
+
+    companion object {
+        const val ERROR_SCHEDULE = R.string.error_schedule
     }
 }

--- a/app/src/main/res/layout/fragment_schedule.xml
+++ b/app/src/main/res/layout/fragment_schedule.xml
@@ -30,9 +30,10 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/schedule_rv_list"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:layout_marginTop="15dp"
             app:layout_constraintTop_toBottomOf="@id/schedule_calendar"
+            app:layout_constraintBottom_toBottomOf="parent"
             tools:listitem="@layout/item_schedule"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_schedule.xml
+++ b/app/src/main/res/layout/item_schedule.xml
@@ -25,7 +25,7 @@
             android:layout_width="180dp"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:text="@{schedule.contents, default = `근로자의 날`}"
+            android:text="@{schedule.content, default = `근로자의 날`}"
             android:textSize="13sp"
             android:textColor="@color/black"
             app:layout_constraintHorizontal_bias="0.8"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,4 +34,5 @@
     <!-- error message -->
     <string name="error_network">서버에 오류가 발생하였습니다.\n 잠시 후 다시 실행해주세요.</string>
     <string name="error_notice">공지사항을 불러올 수 없습니다.</string>
+    <string name="error_schedule">학사일정을 불러올 수 없습니다.</string>
 </resources>


### PR DESCRIPTION
## 목적

> 학사 일정 화면 API 연동

## 내용

![Screenshot_1653137331](https://user-images.githubusercontent.com/85336456/169652229-25db6827-77a6-45b5-980b-0ded9f663666.png)

- [x] 학사 일정 API 연동
- [x] 학사 일정은 변동되는 데이터가 아니므로, 처음에만 API 연동을 진행하고 이 후 로컬 데이터에 저장하여 서버 접근 리소스를 감소