### PR TITLE
Feature : 식당 화면 API 연동

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,11 @@
             android:exported="false" />
         <activity
             android:name=".ui.view.main.MainActivity"
-            android:exported="false" /> <!-- Firebase Cloud Messaging -->
+            android:exported="false" />
+        <activity
+            android:name=".ui.view.cafeteria.CafeteriaActivity"
+            android:exported="false" />
+        <!-- Firebase Cloud Messaging -->
         <service
             android:name=".service.FCMService"
             android:exported="false">

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Cafeteria.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Cafeteria.kt
@@ -1,0 +1,18 @@
+package com.dongyang.android.youdongknowme.data.remote.entity
+
+import com.google.gson.annotations.SerializedName
+
+data class Cafeteria(
+    @SerializedName("range")
+    var range: String,
+    @SerializedName("date")
+    var date: String,
+    @SerializedName("restaurant")
+    var restaurant: String,
+    @SerializedName("menu_division")
+    var menuDivision: String,
+    @SerializedName("menu_content")
+    var menuContent: String,
+    @SerializedName("etc_info")
+    var etcInfo: String
+)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/CafeteriaService.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/CafeteriaService.kt
@@ -1,0 +1,9 @@
+package com.dongyang.android.youdongknowme.data.remote.service
+
+import com.dongyang.android.youdongknowme.data.remote.entity.Cafeteria
+import retrofit2.http.GET
+
+interface CafeteriaService {
+    @GET("/menu")
+    suspend fun getMenuList() : List<Cafeteria>
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/ScheduleService.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/ScheduleService.kt
@@ -6,6 +6,5 @@ import retrofit2.http.GET
 
 interface ScheduleService {
     @GET("/schedule")
-    suspend fun getScheduleList(
-    ) : List<Schedule>
+    suspend fun getScheduleList() : List<Schedule>
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
@@ -1,0 +1,23 @@
+package com.dongyang.android.youdongknowme.data.repository
+
+import com.dongyang.android.youdongknowme.data.remote.entity.Cafeteria
+import com.dongyang.android.youdongknowme.data.remote.service.CafeteriaService
+import com.dongyang.android.youdongknowme.standard.network.ErrorResponseHandler
+import com.dongyang.android.youdongknowme.standard.network.NetworkResult
+import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
+
+class CafeteriaRepository(
+    private val errorResponseHandler: ErrorResponseHandler
+) {
+
+    suspend fun fetchMenuList(code: Int, num: Int): NetworkResult<List<Cafeteria>> {
+
+        return try {
+            val response = RetrofitObject.getNetwork().create(CafeteriaService::class.java).getMenuList()
+            NetworkResult.Success(response)
+        } catch (exception: Exception) {
+            val error = errorResponseHandler.getError(exception)
+            NetworkResult.Error(error)
+        }
+    }
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
@@ -9,8 +9,7 @@ import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
 class CafeteriaRepository(
     private val errorResponseHandler: ErrorResponseHandler
 ) {
-
-    suspend fun fetchMenuList(code: Int, num: Int): NetworkResult<List<Cafeteria>> {
+    suspend fun fetchMenuList(): NetworkResult<List<Cafeteria>> {
         return try {
             val response = RetrofitObject.getNetwork().create(CafeteriaService::class.java).getMenuList()
             NetworkResult.Success(response)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
@@ -11,7 +11,6 @@ class CafeteriaRepository(
 ) {
 
     suspend fun fetchMenuList(code: Int, num: Int): NetworkResult<List<Cafeteria>> {
-
         return try {
             val response = RetrofitObject.getNetwork().create(CafeteriaService::class.java).getMenuList()
             NetworkResult.Success(response)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/DetailRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/DetailRepository.kt
@@ -10,7 +10,6 @@ class DetailRepository(
     private val errorResponseHandler: ErrorResponseHandler
 ) {
     suspend fun fetchNoticeDetail(code: Int, num: Int): NetworkResult<NoticeDetail> {
-
         return try {
             val response = RetrofitObject.getNetwork().create(DetailService::class.java)
                 .getNoticeDetail(code, num)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
@@ -9,6 +9,7 @@ import com.dongyang.android.youdongknowme.data.repository.*
 import com.dongyang.android.youdongknowme.standard.network.ErrorResponseHandler
 import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
 import com.dongyang.android.youdongknowme.ui.view.alarm.AlarmViewModel
+import com.dongyang.android.youdongknowme.ui.view.cafeteria.CafeteriaViewModel
 import com.dongyang.android.youdongknowme.ui.view.depart.DepartViewModel
 import com.dongyang.android.youdongknowme.ui.view.detail.DetailViewModel
 import com.dongyang.android.youdongknowme.ui.view.keyword.KeywordViewModel
@@ -80,6 +81,9 @@ val viewModelModule = module {
     viewModel {
         AlarmViewModel(get())
     }
+    viewModel {
+        CafeteriaViewModel(get())
+    }
 }
 
 val repositoryModule = module {
@@ -106,6 +110,9 @@ val repositoryModule = module {
     }
     single {
         AlarmRepository(get())
+    }
+    single {
+        CafeteriaRepository(get())
     }
 }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaActivity.kt
@@ -1,0 +1,26 @@
+package com.dongyang.android.youdongknowme.ui.view.cafeteria
+
+import com.dongyang.android.youdongknowme.R
+import com.dongyang.android.youdongknowme.databinding.ActivityCafeteriaBinding
+import com.dongyang.android.youdongknowme.standard.base.BaseActivity
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class CafeteriaActivity : BaseActivity<ActivityCafeteriaBinding, CafeteriaViewModel>() {
+    override val layoutResourceId: Int = R.layout.activity_cafeteria
+    override val viewModel: CafeteriaViewModel by viewModel()
+
+    override fun initStartView() {
+        binding.vm = viewModel
+    }
+
+    override fun initDataBinding() {
+        viewModel.menuList.observe(this) {
+
+        }
+    }
+
+    override fun initAfterBinding() {
+        viewModel.fetchCafeteria()
+    }
+
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
@@ -1,0 +1,33 @@
+package com.dongyang.android.youdongknowme.ui.view.cafeteria
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import com.dongyang.android.youdongknowme.data.remote.entity.Cafeteria
+import com.dongyang.android.youdongknowme.data.repository.CafeteriaRepository
+import com.dongyang.android.youdongknowme.standard.base.BaseViewModel
+import com.dongyang.android.youdongknowme.standard.network.NetworkResult
+import kotlinx.coroutines.launch
+
+class CafeteriaViewModel(private val cafeteriaRepository: CafeteriaRepository) : BaseViewModel() {
+
+    private val _menuList: MutableLiveData<List<Cafeteria>> = MutableLiveData(emptyList())
+    val menuList: LiveData<List<Cafeteria>> = _menuList
+
+    fun fetchCafeteria() {
+        viewModelScope.launch {
+            showLoading()
+            when (val result = cafeteriaRepository.fetchMenuList()) {
+                is NetworkResult.Success -> {
+                    val menuList = result.data
+                    _menuList.postValue(menuList)
+                    dismissLoading()
+                }
+                is NetworkResult.Error -> {
+                    handleError(result)
+                    dismissLoading()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_cafeteria.xml
+++ b/app/src/main/res/layout/activity_cafeteria.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.view.cafeteria.CafeteriaActivity">
+
+        <TextView
+            android:id="@+id/cafeteria_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Empty Activity"
+            android:textColor="@color/black"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.dongyang.android.youdongknowme.ui.view.cafeteria.CafeteriaViewModel" />
+    </data>
+</layout>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #67 

## ✍️ 구현 내용

<img width="1462" alt="스크린샷 2022-08-08 오전 6 42 54" src="https://user-images.githubusercontent.com/85336456/183312121-84ae4881-f961-4727-88c2-857374833941.png">

- 식당 화면의 API를 연동
- 식당 화면의 임시 액티비티 생성

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과
