### PR TITLE
Fix : 키워드 화면 진입 시 기존 등록했던 키워드가 체크되지 않는 현상 해결

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/alarm/AlarmViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/alarm/AlarmViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.launch
 
 class AlarmViewModel(private val alarmRepository: AlarmRepository) : BaseViewModel() {
 
-    private val _alarmList: MutableLiveData<List<AlarmEntity>> = MutableLiveData(emptyList())
+    private val _alarmList: MutableLiveData<List<AlarmEntity>> = MutableLiveData()
     val alarmList: LiveData<List<AlarmEntity>> get() = _alarmList
 
     private val _title: MutableLiveData<String> = MutableLiveData()

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.launch
 
 class CafeteriaViewModel(private val cafeteriaRepository: CafeteriaRepository) : BaseViewModel() {
 
-    private val _menuList: MutableLiveData<List<Cafeteria>> = MutableLiveData(emptyList())
+    private val _menuList: MutableLiveData<List<Cafeteria>> = MutableLiveData()
     val menuList: LiveData<List<Cafeteria>> = _menuList
 
     fun fetchCafeteria() {

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/keyword/KeywordViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/keyword/KeywordViewModel.kt
@@ -20,7 +20,7 @@ class KeywordViewModel(
     private val _isFirstLaunch: MutableLiveData<Boolean> = MutableLiveData(false)
     val isFirstLaunch: LiveData<Boolean> get() = _isFirstLaunch
 
-    private val _localKeywordList: MutableLiveData<List<KeywordEntity>> = MutableLiveData(emptyList())
+    private val _localKeywordList: MutableLiveData<List<KeywordEntity>> = MutableLiveData()
     val localKeywordList: LiveData<List<KeywordEntity>> get() = _localKeywordList
 
     private val _checkKeywordList = mutableSetOf<String>()

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeViewModel.kt
@@ -25,11 +25,11 @@ class NoticeViewModel(
     private val _isSearchMode = MutableLiveData(false)
     val isSearchMode: LiveData<Boolean> get() = _isSearchMode
 
-    private val _universityNoticeList: MutableLiveData<List<Notice>> = MutableLiveData(emptyList())
+    private val _universityNoticeList: MutableLiveData<List<Notice>> = MutableLiveData()
 
-    private val _facultyNoticeList: MutableLiveData<List<Notice>> = MutableLiveData(emptyList())
+    private val _facultyNoticeList: MutableLiveData<List<Notice>> = MutableLiveData()
 
-    private val _noticeList: MutableLiveData<List<Notice>> = MutableLiveData(emptyList())
+    private val _noticeList: MutableLiveData<List<Notice>> = MutableLiveData()
     val noticeList: LiveData<List<Notice>> = _noticeList
 
     private val _unVisitedAlarmCount: MutableLiveData<Int> = MutableLiveData()


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #80 

## ✍️ 구현 내용
- 키워드 화면 진입 시 기존 등록한 키워드가 체크표시 되지 않는 현상 해결
  - `MutableLiveData`의 초기값을 `emptyList()`로 지정하면, 진입하자마자 바로 옵저빙을 하면서 생겼던 문제
  - 초기값을 지정하지 않음으로 Bug Fix 👍

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과
