### PR TITLE
Fix : 학과 변경 후에도 이전 학과의 공지사항이 출력되던 오류 수정

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
@@ -28,12 +28,11 @@ class NoticeRepository(
     }
 
     suspend fun fetchDepartmentNotices(
-        department: String,
         page: Int
     ): NetworkResult<List<Notice>> {
         return try {
             val departmentNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
-                .getDepartmentNotice(department, page, DEFAULT_SIZE)
+                .getDepartmentNotice(getUserDepartment(), page, DEFAULT_SIZE)
             NetworkResult.Success(departmentNotices)
         } catch (exception: Exception) {
             val error = errorResponseHandler.getError(exception)
@@ -43,12 +42,11 @@ class NoticeRepository(
 
     suspend fun fetchSearchNotices(
         searchWord: String,
-        department: String,
         page: Int
     ): NetworkResult<List<Notice>> {
         return try {
             val searchNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
-                .getSearchNotice(searchWord, department, page, DEFAULT_SIZE)
+                .getSearchNotice(searchWord, getUserDepartment(), page, DEFAULT_SIZE)
             NetworkResult.Success(searchNotices)
         } catch (exception: Exception) {
             val error = errorResponseHandler.getError(exception)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
@@ -1,6 +1,5 @@
 package com.dongyang.android.youdongknowme.ui.view.notice
 
-import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.dongyang.android.youdongknowme.R
@@ -117,5 +116,11 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>() {
     private fun navigateToDetail(url: String) {
         val intent = DetailActivity.newIntent(requireContext(), url)
         startActivity(intent)
+    }
+
+    // TODO 더 나은 로직으로 제거
+    override fun onResume() {
+        super.onResume()
+        viewModel.refreshIfChangedDepartment()
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeViewModel.kt
@@ -11,7 +11,7 @@ import com.dongyang.android.youdongknowme.ui.view.util.Event
 import kotlinx.coroutines.launch
 
 class NoticeViewModel(
-    private val noticeRepository: NoticeRepository
+    private val noticeRepository: NoticeRepository,
 ) : BaseViewModel() {
 
     private val _errorState: MutableLiveData<Event<Int>> = MutableLiveData()
@@ -26,27 +26,20 @@ class NoticeViewModel(
     private val _selectedTab: MutableLiveData<Event<NoticeTabType>> = MutableLiveData()
     val selectedTab: LiveData<Event<NoticeTabType>> = _selectedTab
 
-    private val _myDepartment: MutableLiveData<String> = MutableLiveData()
-    private val myDepartment: LiveData<String> = _myDepartment
-
     private val _universityNotices: MutableLiveData<List<Notice>?> = MutableLiveData()
     val universityNotices: LiveData<List<Notice>?> = _universityNotices
 
     private val _departmentNotices: MutableLiveData<List<Notice>?> = MutableLiveData()
     val departmentNotices: LiveData<List<Notice>?> = _departmentNotices
 
+    private var department: String
     private var universityNoticeCurrentPage = 1
     private var departmentNoticeCurrentPage = 1
 
     init {
         updateSelectedTabType(NoticeTabType.SCHOOL)
         fetchUniversityNotices()
-        getUserDepartment()
-    }
-
-    private fun getUserDepartment() {
-        val myDepartment = noticeRepository.getUserDepartment()
-        _myDepartment.postValue(myDepartment)
+        department = noticeRepository.getUserDepartment()
     }
 
     fun updateSelectedTabType(tabType: NoticeTabType) {
@@ -88,7 +81,6 @@ class NoticeViewModel(
         viewModelScope.launch {
             when (val result =
                 noticeRepository.fetchDepartmentNotices(
-                    myDepartment.value.toString(),
                     departmentNoticeCurrentPage
                 )) {
                 is NetworkResult.Success -> {
@@ -132,7 +124,6 @@ class NoticeViewModel(
                 NoticeTabType.FACULTY -> viewModelScope.launch {
                     when (val result =
                         noticeRepository.fetchDepartmentNotices(
-                            myDepartment.value.toString(),
                             DEFAULT_REFRESH_PAGE
                         )) {
                         is NetworkResult.Success -> {
@@ -149,6 +140,15 @@ class NoticeViewModel(
                     }
                 }
             }
+        }
+    }
+
+    fun refreshIfChangedDepartment() {
+        val currentDepartment = noticeRepository.getUserDepartment()
+
+        if (department != currentDepartment) {
+            department = currentDepartment
+            refreshNotices()
         }
     }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/search/SearchViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/search/SearchViewModel.kt
@@ -11,7 +11,7 @@ import com.dongyang.android.youdongknowme.ui.view.util.Event
 import kotlinx.coroutines.launch
 
 class SearchViewModel(
-    private val noticeRepository: NoticeRepository
+    private val noticeRepository: NoticeRepository,
 ) : BaseViewModel() {
 
     private val _errorState: MutableLiveData<Event<Int>> = MutableLiveData()
@@ -70,7 +70,6 @@ class SearchViewModel(
             when (val result =
                 noticeRepository.fetchSearchNotices(
                     searchContent.value.toString(),
-                    myDepartment.value.toString(),
                     searchNoticeCurrentPage
                 )) {
                 is NetworkResult.Success -> {


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #242 

## ✍️ 구현 내용
- 학과 변경 후에도 이전 학과의 공지사항이 출력되던 오류 수정

## 📷 구현 영상

## ✔️ 확인 사항
- [ ] 컨벤션에 맞는 PR 타이틀
- [ ] 관련 이슈 연결
- [ ] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
