### PR TITLE
Feat : 학사 일정 데이트 피커

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
@@ -41,8 +41,10 @@ class DatePickerDialog(
         binding.numberpickerDialogDatepickerMonth.wrapSelectorWheel = false
 
         // editText 설정 막기
-        binding.numberpickerDialogDatepickerYear.descendantFocusability = NumberPicker.FOCUS_BLOCK_DESCENDANTS
-        binding.numberpickerDialogDatepickerMonth.descendantFocusability = NumberPicker.FOCUS_BLOCK_DESCENDANTS
+        binding.numberpickerDialogDatepickerYear.descendantFocusability =
+            NumberPicker.FOCUS_BLOCK_DESCENDANTS
+        binding.numberpickerDialogDatepickerMonth.descendantFocusability =
+            NumberPicker.FOCUS_BLOCK_DESCENDANTS
 
         // 연도 및 월의 최소/최대값 설정
         with(binding.numberpickerDialogDatepickerYear) {
@@ -71,8 +73,14 @@ class DatePickerDialog(
         }
 
         binding.tvDialogPermissionComplete.setOnClickListener {
-            viewModel.setDatePicker(binding.numberpickerDialogDatepickerYear.value, binding.numberpickerDialogDatepickerMonth.value)
-            dateSelectedListener.onDateSelected(binding.numberpickerDialogDatepickerYear.value, binding.numberpickerDialogDatepickerMonth.value)
+            viewModel.setDatePicker(
+                binding.numberpickerDialogDatepickerYear.value,
+                binding.numberpickerDialogDatepickerMonth.value
+            )
+            dateSelectedListener.onDateSelected(
+                binding.numberpickerDialogDatepickerYear.value,
+                binding.numberpickerDialogDatepickerMonth.value
+            )
             dismiss()
         }
 
@@ -84,7 +92,10 @@ class DatePickerDialog(
         val dialog = super.onCreateDialog(savedInstanceState)
 
         dialog.window?.let { window ->
-            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            window.setLayout(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
             window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
         }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
@@ -8,7 +8,10 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.NumberPicker
 import androidx.fragment.app.DialogFragment
+import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.DialogDatepickerBinding
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.threeten.bp.LocalDate
 
@@ -16,7 +19,7 @@ class DatePickerDialog(
     val year: Int,
     val month: Int,
     private val dateSelectedListener: ScheduleFragment,
-) : DialogFragment() {
+) : BottomSheetDialogFragment() {
 
     private var _binding: DialogDatepickerBinding? = null
     private val binding get() = _binding!!
@@ -85,29 +88,7 @@ class DatePickerDialog(
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-
-        val dialog = super.onCreateDialog(savedInstanceState)
-
-        dialog.window?.let { window ->
-            window.setLayout(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-            )
-            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-        }
-
-        return dialog
-    }
-
-    override fun onStart() {
-
-        super.onStart()
-
-        dialog?.window?.let { window ->
-            val layoutParams = window.attributes
-            layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT
-            window.attributes = layoutParams
-        }
+        return BottomSheetDialog(requireContext(), R.style.CustomBottomSheetDialogTheme)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
@@ -5,26 +5,23 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
 import android.widget.NumberPicker
-import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
 import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.DialogDatepickerBinding
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import org.koin.androidx.viewmodel.ext.android.viewModel
+import com.prolificinteractive.materialcalendarview.CalendarDay
 import org.threeten.bp.LocalDate
 
 class DatePickerDialog(
-    val year: Int,
-    val month: Int,
-    private val dateSelectedListener: ScheduleFragment,
+    private val year: Int,
+    private val month: Int,
+    private val listener: ScheduleClickListener
 ) : BottomSheetDialogFragment() {
 
     private var _binding: DialogDatepickerBinding? = null
     private val binding get() = _binding!!
-
-    private val viewModel: ScheduleViewModel by viewModel()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -52,7 +49,9 @@ class DatePickerDialog(
         with(binding.numberpickerDialogDatepickerYear) {
             minValue = currentYear - 1
             maxValue = currentYear + 1
-            displayedValues=((minValue..maxValue).map{"$it 년"}.toTypedArray())
+            displayedValues =
+                ((minValue..maxValue).map { "$it${getString(R.string.calendar_year)}" }
+                    .toTypedArray())
         }
 
         // 월 최소/최대값 설정 및 출력 방식 설정
@@ -65,29 +64,36 @@ class DatePickerDialog(
                 maxValue = if (newYear == currentYear + 1) 2 else 12
             }
 
-            displayedValues=((minValue..maxValue).map{"$it 월"}.toTypedArray())
+            displayedValues =
+                ((minValue..maxValue).map { "$it${getString(R.string.calendar_month)}" }
+                    .toTypedArray())
         }
 
         // 초기 설정
         binding.numberpickerDialogDatepickerYear.value = year
         binding.numberpickerDialogDatepickerMonth.value = month
 
-        binding.tvDialogPermissionComplete.setOnClickListener {
-            viewModel.setDatePicker(
-                binding.numberpickerDialogDatepickerYear.value,
-                binding.numberpickerDialogDatepickerMonth.value
-            )
-            dateSelectedListener.onDateSelected(
-                binding.numberpickerDialogDatepickerYear.value,
-                binding.numberpickerDialogDatepickerMonth.value
-            )
-            dismiss()
-        }
-
         return view
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.tvDialogPermissionComplete.setOnClickListener {
+            val year = binding.numberpickerDialogDatepickerYear.value
+            val month = binding.numberpickerDialogDatepickerMonth.value
+            val date = CalendarDay.from(year, month, 1)
+
+            listener.buttonClick(date = date)
+
+            dismiss()
+        }
+    }
+
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+
         return BottomSheetDialog(requireContext(), R.style.CustomBottomSheetDialogTheme)
     }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
@@ -16,7 +16,6 @@ class DatePickerDialog(
     val year: Int,
     val month: Int,
     private val dateSelectedListener: ScheduleFragment,
-    private val cancelListener: (() -> Unit)? = null,
 ) : DialogFragment() {
 
     private var _binding: DialogDatepickerBinding? = null
@@ -65,12 +64,6 @@ class DatePickerDialog(
         // 초기 설정
         binding.numberpickerDialogDatepickerYear.value = year
         binding.numberpickerDialogDatepickerMonth.value = month
-
-        // 취소 버튼 클릭시
-        binding.tvDialogDatepickerCancel.setOnClickListener {
-            cancelListener?.invoke()
-            dismiss()
-        }
 
         binding.tvDialogPermissionComplete.setOnClickListener {
             viewModel.setDatePicker(

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
@@ -45,12 +45,14 @@ class DatePickerDialog(
         binding.numberpickerDialogDatepickerMonth.descendantFocusability =
             NumberPicker.FOCUS_BLOCK_DESCENDANTS
 
-        // 연도 및 월의 최소/최대값 설정
+        // 연도 최소/최대값 설정 및 출력 방식 설정
         with(binding.numberpickerDialogDatepickerYear) {
             minValue = currentYear - 1
             maxValue = currentYear + 1
+            displayedValues=((minValue..maxValue).map{"$it 년"}.toTypedArray())
         }
 
+        // 월 최소/최대값 설정 및 출력 방식 설정
         with(binding.numberpickerDialogDatepickerMonth) {
             minValue = 1
             maxValue = if (year == currentYear + 1) 2 else 12
@@ -59,6 +61,8 @@ class DatePickerDialog(
             binding.numberpickerDialogDatepickerYear.setOnValueChangedListener { _, _, newYear ->
                 maxValue = if (newYear == currentYear + 1) 2 else 12
             }
+
+            displayedValues=((minValue..maxValue).map{"$it 월"}.toTypedArray())
         }
 
         // 초기 설정

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
@@ -1,9 +1,11 @@
 package com.dongyang.android.youdongknowme.ui.view.schedule
 
+import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.NumberPicker
 import androidx.fragment.app.DialogFragment
 import com.dongyang.android.youdongknowme.databinding.DialogDatepickerBinding
@@ -27,7 +29,7 @@ class DatePickerDialog(
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        
+
         _binding = DialogDatepickerBinding.inflate(inflater, container, false)
         val view = binding.root
 
@@ -77,7 +79,31 @@ class DatePickerDialog(
         return view
     }
 
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+
+        val dialog = super.onCreateDialog(savedInstanceState)
+
+        dialog.window?.let { window ->
+            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        }
+
+        return dialog
+    }
+
+    override fun onStart() {
+
+        super.onStart()
+
+        dialog?.window?.let { window ->
+            val layoutParams = window.attributes
+            layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT
+            window.attributes = layoutParams
+        }
+    }
+
     override fun onDestroyView() {
+
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/DatePickerDialog.kt
@@ -1,0 +1,84 @@
+package com.dongyang.android.youdongknowme.ui.view.schedule
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.NumberPicker
+import androidx.fragment.app.DialogFragment
+import com.dongyang.android.youdongknowme.databinding.DialogDatepickerBinding
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.threeten.bp.LocalDate
+
+class DatePickerDialog(
+    val year: Int,
+    val month: Int,
+    private val dateSelectedListener: ScheduleFragment,
+    private val cancelListener: (() -> Unit)? = null,
+) : DialogFragment() {
+
+    private var _binding: DialogDatepickerBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ScheduleViewModel by viewModel()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        
+        _binding = DialogDatepickerBinding.inflate(inflater, container, false)
+        val view = binding.root
+
+        // 현재 연도
+        val currentYear = LocalDate.now().year
+
+        // 순환 막기
+        binding.numberpickerDialogDatepickerYear.wrapSelectorWheel = false
+        binding.numberpickerDialogDatepickerMonth.wrapSelectorWheel = false
+
+        // editText 설정 막기
+        binding.numberpickerDialogDatepickerYear.descendantFocusability = NumberPicker.FOCUS_BLOCK_DESCENDANTS
+        binding.numberpickerDialogDatepickerMonth.descendantFocusability = NumberPicker.FOCUS_BLOCK_DESCENDANTS
+
+        // 연도 및 월의 최소/최대값 설정
+        with(binding.numberpickerDialogDatepickerYear) {
+            minValue = currentYear - 1
+            maxValue = currentYear + 1
+        }
+
+        with(binding.numberpickerDialogDatepickerMonth) {
+            minValue = 1
+            maxValue = if (year == currentYear + 1) 2 else 12
+
+            // 연도 선택에 따른 월의 최대값 동적 설정
+            binding.numberpickerDialogDatepickerYear.setOnValueChangedListener { _, _, newYear ->
+                maxValue = if (newYear == currentYear + 1) 2 else 12
+            }
+        }
+
+        // 초기 설정
+        binding.numberpickerDialogDatepickerYear.value = year
+        binding.numberpickerDialogDatepickerMonth.value = month
+
+        // 취소 버튼 클릭시
+        binding.tvDialogDatepickerCancel.setOnClickListener {
+            cancelListener?.invoke()
+            dismiss()
+        }
+
+        binding.tvDialogPermissionComplete.setOnClickListener {
+            viewModel.setDatePicker(binding.numberpickerDialogDatepickerYear.value, binding.numberpickerDialogDatepickerMonth.value)
+            dateSelectedListener.onDateSelected(binding.numberpickerDialogDatepickerYear.value, binding.numberpickerDialogDatepickerMonth.value)
+            dismiss()
+        }
+
+        return view
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleClickListener.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleClickListener.kt
@@ -1,0 +1,7 @@
+package com.dongyang.android.youdongknowme.ui.view.schedule
+
+import com.prolificinteractive.materialcalendarview.CalendarDay
+
+interface ScheduleClickListener {
+    fun buttonClick(date: CalendarDay)
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleFragment.kt
@@ -18,7 +18,8 @@ interface OnDateSelectedListener {
 }
 
 /* 학사 일정 화면 */
-class ScheduleFragment : BaseFragment<FragmentScheduleBinding, ScheduleViewModel>(), OnDateSelectedListener {
+class ScheduleFragment : BaseFragment<FragmentScheduleBinding, ScheduleViewModel>(),
+    OnDateSelectedListener {
 
     override val layoutResourceId: Int = R.layout.fragment_schedule
     override val viewModel: ScheduleViewModel by viewModel()
@@ -45,8 +46,22 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding, ScheduleViewModel
 
         viewModel.setPickedDate(binding.mvScheduleCalendar.currentDate)
 
-        binding.mvScheduleCalendar.leftArrow.setTintList(ColorStateList.valueOf(ContextCompat.getColor(this.requireContext(), R.color.blue300)))
-        binding.mvScheduleCalendar.rightArrow.setTintList(ColorStateList.valueOf(ContextCompat.getColor(this.requireContext(), R.color.blue300)))
+        binding.mvScheduleCalendar.leftArrow.setTintList(
+            ColorStateList.valueOf(
+                ContextCompat.getColor(
+                    this.requireContext(),
+                    R.color.blue300
+                )
+            )
+        )
+        binding.mvScheduleCalendar.rightArrow.setTintList(
+            ColorStateList.valueOf(
+                ContextCompat.getColor(
+                    this.requireContext(),
+                    R.color.blue300
+                )
+            )
+        )
 
         adapter = ScheduleAdapter()
         binding.rvScheduleList.apply {
@@ -91,7 +106,11 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding, ScheduleViewModel
         }
 
         binding.mvScheduleCalendar.setOnTitleClickListener {
-            val dialog = DatePickerDialog(year = year.toInt(), month = month.toInt(), dateSelectedListener = this)
+            val dialog = DatePickerDialog(
+                year = year.toInt(),
+                month = month.toInt(),
+                dateSelectedListener = this
+            )
             dialog.show(requireActivity().supportFragmentManager, "CustomDialog")
         }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleViewModel.kt
@@ -41,6 +41,11 @@ class ScheduleViewModel(private val scheduleRepository: ScheduleRepository) : Ba
         _pickMonth.value = date.month
     }
 
+    fun setDatePicker(year: Int, month: Int) {
+        _pickYear.value = year
+        _pickMonth.value = month
+    }
+
     fun getSchedules() {
         // 로컬에 저장한 데이터가 없으면 네트워크에서 데이터를 받아와 로컬에 저장 및 화면에 출력
         if (scheduleRepository.getLocalSchedules() == NO_SCHEDULE) {
@@ -51,7 +56,6 @@ class ScheduleViewModel(private val scheduleRepository: ScheduleRepository) : Ba
                         val scheduleList = result.data
 
                         // 선택한 연월 조건에 따라 리스트 출력
-
                         _scheduleList.postValue(getSchedulesForPickDate(scheduleList))
 
                         scheduleRepository.setLocalSchedules(Gson().toJson(scheduleList))

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleViewModel.kt
@@ -36,14 +36,14 @@ class ScheduleViewModel(private val scheduleRepository: ScheduleRepository) : Ba
     private val _pickMonth = MutableLiveData<Int>()
     val pickMonth: LiveData<Int> = _pickMonth
 
+    private val _selectedDate = MutableLiveData<CalendarDay>()
+    val selectedDate: LiveData<CalendarDay> = _selectedDate
+
     fun setPickedDate(date: CalendarDay) {
+        _selectedDate.value = date
         _pickYear.value = date.year
         _pickMonth.value = date.month
-    }
-
-    fun setDatePicker(year: Int, month: Int) {
-        _pickYear.value = year
-        _pickMonth.value = month
+        getSchedules()
     }
 
     fun getSchedules() {

--- a/app/src/main/res/drawable/bg_white_radius_20dp.xml
+++ b/app/src/main/res/drawable/bg_white_radius_20dp.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="20dp" />
+    <solid android:color="@color/white" />
+</shape>

--- a/app/src/main/res/drawable/ic_dialog_handle.xml
+++ b/app/src/main/res/drawable/ic_dialog_handle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="5dp"
+    android:viewportWidth="48"
+    android:viewportHeight="5">
+  <path
+      android:pathData="M0,2.035C0,0.911 0.911,0 2.035,0H45.965C47.089,0 48,0.911 48,2.035V2.035C48,3.159 47.089,4.07 45.965,4.07H2.035C0.911,4.07 0,3.159 0,2.035V2.035Z"
+      android:fillColor="#7F8295"/>
+</vector>

--- a/app/src/main/res/layout/dialog_datepicker.xml
+++ b/app/src/main/res/layout/dialog_datepicker.xml
@@ -10,8 +10,11 @@
 
     <NumberPicker
         android:id="@+id/numberpicker_dialog_datepicker_year"
+        style="@style/PretendardMedium24"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginVertical="36dp"
         android:theme="@style/Theme.YouDongKnowMe.NumberPicker"
         app:layout_constraintEnd_toStartOf="@id/numberpicker_dialog_datepicker_month"
         app:layout_constraintStart_toStartOf="parent"
@@ -19,38 +22,29 @@
 
     <NumberPicker
         android:id="@+id/numberpicker_dialog_datepicker_month"
+        style="@style/PretendardMedium24"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="50dp"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginVertical="36dp"
         android:theme="@style/Theme.YouDongKnowMe.NumberPicker"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/numberpicker_dialog_datepicker_year"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/tv_dialog_datepicker_cancel"
-        style="@style/PretendardSemiBold16"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:layout_marginEnd="28dp"
-        android:layout_marginBottom="20dp"
-        android:hint="@string/dialog_datepicker_cancel"
-        android:textColor="@color/blue300"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/tv_dialog_permission_complete"
-        app:layout_constraintTop_toBottomOf="@+id/numberpicker_dialog_datepicker_month" />
-
-    <TextView
+    <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/tv_dialog_permission_complete"
-        style="@style/PretendardSemiBold16"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="30dp"
-        android:layout_marginBottom="20dp"
-        android:hint="@string/dialog_datepicker_comlete"
-        android:textColor="@color/blue300"
+        style="@style/PretendardMedium24"
+        android:layout_width="0dp"
+        android:layout_height="56dp"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginVertical="20dp"
+        android:background="@drawable/btn_gray_to_blue_10dp_enabled"
+        android:text="@string/dialog_datepicker_comlete"
+        android:textColor="@color/white"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/numberpicker_dialog_datepicker_year" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_datepicker.xml
+++ b/app/src/main/res/layout/dialog_datepicker.xml
@@ -5,27 +5,27 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="20dp"
-    android:backgroundTint="@color/white"
-    android:background="@drawable/bg_stroke_gray300_radius_2dp">
+    android:background="@drawable/bg_stroke_gray300_radius_2dp"
+    android:backgroundTint="@color/white">
 
     <NumberPicker
         android:id="@+id/numberpicker_dialog_datepicker_year"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:theme="@style/Theme.YouDongKnowMe.NumberPicker"
         app:layout_constraintEnd_toStartOf="@id/numberpicker_dialog_datepicker_month"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:theme="@style/Theme.YouDongKnowMe.NumberPicker"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <NumberPicker
         android:id="@+id/numberpicker_dialog_datepicker_month"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="50dp"
+        android:theme="@style/Theme.YouDongKnowMe.NumberPicker"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/numberpicker_dialog_datepicker_year"
-        app:layout_constraintTop_toTopOf="parent"
-        android:theme="@style/Theme.YouDongKnowMe.NumberPicker" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/tv_dialog_datepicker_cancel"

--- a/app/src/main/res/layout/dialog_datepicker.xml
+++ b/app/src/main/res/layout/dialog_datepicker.xml
@@ -10,20 +10,22 @@
 
     <NumberPicker
         android:id="@+id/numberpicker_dialog_datepicker_year"
-        android:layout_width="63dp"
-        android:layout_height="124dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         app:layout_constraintEnd_toStartOf="@id/numberpicker_dialog_datepicker_month"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        android:theme="@style/Theme.YouDongKnowMe.NumberPicker"/>
 
     <NumberPicker
         android:id="@+id/numberpicker_dialog_datepicker_month"
-        android:layout_width="63dp"
-        android:layout_height="124dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginStart="50dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/numberpicker_dialog_datepicker_year"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        android:theme="@style/Theme.YouDongKnowMe.NumberPicker" />
 
     <TextView
         android:id="@+id/tv_dialog_datepicker_cancel"

--- a/app/src/main/res/layout/dialog_datepicker.xml
+++ b/app/src/main/res/layout/dialog_datepicker.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="20dp"
+    android:backgroundTint="@color/white"
+    android:background="@drawable/bg_stroke_gray300_radius_2dp">
+
+    <NumberPicker
+        android:id="@+id/numberpicker_dialog_datepicker_year"
+        android:layout_width="63dp"
+        android:layout_height="124dp"
+        app:layout_constraintEnd_toStartOf="@id/numberpicker_dialog_datepicker_month"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <NumberPicker
+        android:id="@+id/numberpicker_dialog_datepicker_month"
+        android:layout_width="63dp"
+        android:layout_height="124dp"
+        android:layout_marginStart="50dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/numberpicker_dialog_datepicker_year"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_dialog_datepicker_cancel"
+        style="@style/PretendardSemiBold16"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:layout_marginEnd="28dp"
+        android:layout_marginBottom="20dp"
+        android:hint="@string/dialog_datepicker_cancel"
+        android:textColor="@color/blue300"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/tv_dialog_permission_complete"
+        app:layout_constraintTop_toBottomOf="@+id/numberpicker_dialog_datepicker_month" />
+
+    <TextView
+        android:id="@+id/tv_dialog_permission_complete"
+        style="@style/PretendardSemiBold16"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="30dp"
+        android:layout_marginBottom="20dp"
+        android:hint="@string/dialog_datepicker_comlete"
+        android:textColor="@color/blue300"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_datepicker.xml
+++ b/app/src/main/res/layout/dialog_datepicker.xml
@@ -4,9 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="20dp"
-    android:background="@drawable/bg_stroke_gray300_radius_2dp"
-    android:backgroundTint="@color/white">
+    android:layout_margin="20dp">
 
     <NumberPicker
         android:id="@+id/numberpicker_dialog_datepicker_year"
@@ -46,5 +44,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/numberpicker_dialog_datepicker_year" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_datepicker.xml
+++ b/app/src/main/res/layout/dialog_datepicker.xml
@@ -6,6 +6,15 @@
     android:layout_height="wrap_content"
     android:layout_margin="20dp">
 
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_dialog_handle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginTop="10dp"/>
+
     <NumberPicker
         android:id="@+id/numberpicker_dialog_datepicker_year"
         style="@style/PretendardMedium24"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,4 +148,8 @@
     <string name="dialog_permission_early_content">내용</string>
     <string name="dialog_permission_early_cancel">취소</string>
     <string name="dialog_permission_early_complete">설정 화면 이동</string>
+
+    <!-- datepicker dialog -->
+    <string name="dialog_datepicker_cancel">취소</string>
+    <string name="dialog_datepicker_comlete">저장</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,6 +150,5 @@
     <string name="dialog_permission_early_complete">설정 화면 이동</string>
 
     <!-- datepicker dialog -->
-    <string name="dialog_datepicker_cancel">취소</string>
-    <string name="dialog_datepicker_comlete">저장</string>
+    <string name="dialog_datepicker_comlete">완료</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -29,4 +29,12 @@
         <item name="android:fontFamily">@font/pretendard_medium</item>
         <item name="android:textSize">@dimen/font_size_12</item>
     </style>
+
+    <style name="CustomBottomSheetDialogTheme" parent="Theme.Design.Light.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/CustomBottomSheetCornerStyle</item>
+    </style>
+
+    <style name="CustomBottomSheetCornerStyle" parent="Widget.Design.BottomSheet.Modal">
+        <item name="android:background">@drawable/bg_white_radius_20dp</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -28,7 +28,7 @@
     </style>
 
     <!-- 데이트 픽커 스타일 지정 -->
-    <style name="Theme.YouDongKnowMe.NumberPicker" parent="Theme.YouDongKnowMe" >
+    <style name="Theme.YouDongKnowMe.NumberPicker" parent="Theme.YouDongKnowMe">
         <item name="colorControlNormal">@color/blue200</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -26,4 +26,9 @@
         <item name="android:textSize">16dp</item>
         <item name="android:textColor">@color/gray500</item>
     </style>
+
+    <!-- 데이트 픽커 스타일 지정 -->
+    <style name="Theme.YouDongKnowMe.NumberPicker" parent="Theme.YouDongKnowMe" >
+        <item name="colorControlNormal">@color/blue200</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #258 

## ✍️ 구현 내용
- 학사 일정 데이트 피커 바텀 시트를 제작하였습니다.
- 현재 일 기준 전년도와 다음년도 2월까지 학사 일정을 확인 할 수 있습니다.
- 데이트 피커로 일정 설정 혹은 화살표로 일정 목록 변경이 가능합니다.
- 일정 날짜 변동에 따라 데이트 피커에 반영되도록 제작하였습니다.

## 📷 구현 영상

https://github.com/user-attachments/assets/67ee7c4d-feb9-4550-99d4-11d0e1b1ff44


## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과
