### PR TITLE
Feat : 웹 뷰 디자인 수정 및 개인정보 처리방침,문의하기 웹 뷰로 출력

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,9 @@
             android:name=".ui.view.depart.OnboardingDepartActivity"
             android:exported="false" />
         <activity
+            android:name=".ui.view.web.WebActivity"
+            android:exported="false" />
+        <activity
             android:name=".ui.view.splash.SplashActivity"
             android:exported="true"
             android:theme="@style/Theme.YouDongKnowMe.Splash">

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
@@ -3,7 +3,6 @@ package com.dongyang.android.youdongknowme.ui.view.setting
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Build
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.core.content.ContextCompat
@@ -13,6 +12,7 @@ import com.dongyang.android.youdongknowme.standard.base.BaseFragment
 import com.dongyang.android.youdongknowme.ui.view.depart.DepartActivity
 import com.dongyang.android.youdongknowme.ui.view.keyword.KeywordActivity
 import com.dongyang.android.youdongknowme.ui.view.license.LicenseActivity
+import com.dongyang.android.youdongknowme.ui.view.web.WebActivity
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 /* 설정 화면 */
@@ -33,7 +33,6 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
     }
 
     override fun initDataBinding() {
-
         viewModel.myDepartment.observe(viewLifecycleOwner) { myDepartment ->
             binding.tvSettingDepartment.text = myDepartment
         }
@@ -102,17 +101,17 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
         }
 
         binding.btnSettingAppHelp.setOnClickListener {
-            val intent = Intent(
-                Intent.ACTION_VIEW,
-                Uri.parse("https://docs.google.com/forms/d/e/1FAIpQLSeRTKalenelmffTbCZeK4mqmQg0palobghkXSoie1FlmV22ZQ/viewform")
+            val intent = WebActivity.newIntent(
+                requireContext(),
+                "https://tally.so/r/n9oq91"
             )
             startActivity(intent)
         }
 
         binding.btnSettingAppPersonalPolicy.setOnClickListener {
-            val intent = Intent(
-                Intent.ACTION_VIEW,
-                Uri.parse("https://sites.google.com/view/dmforu-privacy-policy/%ED%99%88")
+            val intent = WebActivity.newIntent(
+                requireContext(),
+                "https://sites.google.com/view/dmforu-privacy-policy/%ED%99%88"
             )
             startActivity(intent)
         }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/web/WebActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/web/WebActivity.kt
@@ -1,0 +1,38 @@
+package com.dongyang.android.youdongknowme.ui.view.web
+
+import android.content.Context
+import android.content.Intent
+import com.dongyang.android.youdongknowme.R
+import com.dongyang.android.youdongknowme.databinding.ActivityWebBinding
+import com.dongyang.android.youdongknowme.standard.base.BaseActivity
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class WebActivity : BaseActivity<ActivityWebBinding, WebViewModel>() {
+
+    override val layoutResourceId: Int = R.layout.activity_web
+    override val viewModel: WebViewModel by viewModel()
+
+    override fun initStartView() {
+        val url = intent.getStringExtra(KEY_URL)
+        binding.wvWeb.loadUrl(url.toString())
+        binding.btnWebClose.setOnClickListener {
+            finish()
+        }
+    }
+
+    override fun initDataBinding() {
+    }
+
+    override fun initAfterBinding() {
+    }
+
+    companion object {
+        private const val KEY_URL = "url"
+
+        fun newIntent(context: Context, url: String): Intent {
+            return Intent(context, WebActivity::class.java).apply {
+                putExtra(KEY_URL, url)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/web/WebActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/web/WebActivity.kt
@@ -20,11 +20,9 @@ class WebActivity : BaseActivity<ActivityWebBinding, WebViewModel>() {
         }
     }
 
-    override fun initDataBinding() {
-    }
+    override fun initDataBinding() = Unit
 
-    override fun initAfterBinding() {
-    }
+    override fun initAfterBinding() = Unit
 
     companion object {
         private const val KEY_URL = "url"

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/web/WebActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/web/WebActivity.kt
@@ -2,6 +2,7 @@ package com.dongyang.android.youdongknowme.ui.view.web
 
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
 import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.ActivityWebBinding
 import com.dongyang.android.youdongknowme.standard.base.BaseActivity
@@ -30,6 +31,7 @@ class WebActivity : BaseActivity<ActivityWebBinding, WebViewModel>() {
         fun newIntent(context: Context, url: String): Intent {
             return Intent(context, WebActivity::class.java).apply {
                 putExtra(KEY_URL, url)
+                flags = FLAG_ACTIVITY_SINGLE_TOP
             }
         }
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/web/WebViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/web/WebViewModel.kt
@@ -1,0 +1,6 @@
+package com.dongyang.android.youdongknowme.ui.view.web
+
+import com.dongyang.android.youdongknowme.standard.base.BaseViewModel
+
+class WebViewModel : BaseViewModel() {
+}

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -20,14 +20,14 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginVertical="4dp"
-                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
                 android:clickable="true"
                 android:contentDescription="@null"
                 android:focusable="true"
                 android:padding="8dp"
                 android:src="@drawable/ic_close"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView

--- a/app/src/main/res/layout/activity_web.xml
+++ b/app/src/main/res/layout/activity_web.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_web_top"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/btn_web_close"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="4dp"
+                android:layout_marginEnd="16dp"
+                android:clickable="true"
+                android:contentDescription="@null"
+                android:focusable="true"
+                android:padding="8dp"
+                android:src="@drawable/ic_close"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <WebView
+            android:id="@+id/wv_web"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cl_web_top" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/activity_web.xml
+++ b/app/src/main/res/layout/activity_web.xml
@@ -5,30 +5,19 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_web_top"
-            android:layout_width="0dp"
+        <ImageView
+            android:id="@+id/btn_web_close"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginVertical="4dp"
+            android:layout_marginEnd="16dp"
+            android:clickable="true"
+            android:contentDescription="@null"
+            android:focusable="true"
+            android:padding="8dp"
+            android:src="@drawable/ic_close"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <ImageView
-                android:id="@+id/btn_web_close"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="4dp"
-                android:layout_marginEnd="16dp"
-                android:clickable="true"
-                android:contentDescription="@null"
-                android:focusable="true"
-                android:padding="8dp"
-                android:src="@drawable/ic_close"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            app:layout_constraintTop_toTopOf="parent" />
 
         <WebView
             android:id="@+id/wv_web"
@@ -37,7 +26,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cl_web_top" />
+            app:layout_constraintTop_toBottomOf="@id/btn_web_close" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #278

## ✍️ 구현 내용
- 공지사항 웹 뷰의 닫기 버튼을 우측으로 이동했습니다.
- 개인정보처리방침, 문의하기 버튼 클릭 시 외부 페이지가 아닌 웹 뷰를 이용합니다.

## 📷 구현 영상

<img width="314" alt="스크린샷 2025-02-15 오후 8 15 10" src="https://github.com/user-attachments/assets/030e3a12-81d9-4304-96e2-2129dd8143db" />
<img width="300" alt="스크린샷 2025-02-15 오후 8 15 14" src="https://github.com/user-attachments/assets/8b598efa-dff5-4c51-a7ad-861b879bdae8" />
<img width="341" alt="스크린샷 2025-02-15 오후 8 03 00" src="https://github.com/user-attachments/assets/e53adeac-143a-4bd1-a0b9-cbe5716b34cd" />


## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
